### PR TITLE
Use a stable download URL

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$url        = 'https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-16.6.exe'  
+$url        = 'https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-17.1.exe?noredirect'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -11,10 +11,10 @@ $packageArgs = @{
 
   softwareName  = 'screamingfrog*' 
 
-  checksum      = '0BB6AFC5A5A002A821794115E9EE23154486B00639EBFD8EF1B97EA73998DB96'
+  checksum      = '8E83F42A6C7AD62060EABEAFD0AA6EDAE3753C7FFB678FC9DA3F81901118703D'
   checksumType  = 'sha256' 
 
   silentArgs    = "ScreamingFrogSEOSpider-VERSION.exe /S"
 }
 
-Install-ChocolateyPackage @packageArgs 
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
As you probably know, it is impossible to download older versions of Screaming Frog. Trying to download an old version results in a redirect, which will automatically download the newest release:

```
$ curl -v https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-16.7.exe
[...]
< HTTP/2 301 
< server: nginx
< date: Wed, 24 Aug 2022 09:11:50 GMT
< content-type: text/html; charset=iso-8859-1
< content-length: 296
< location: https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-17.1.exe
```

As a result, trying to install an older version of Screaming Frog with Chocolatey will fail (because it will download the wrong version and the checksum verification will fail).

However, I've talked to the awesome Screaming Frog support and they've made some changes and finally provide a stable download URL for older versions. When adding the "noredirect" URL parameter, it will no longer redirect, but instead let's you download an old release:

```
$ curl -v https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-16.7.exe
[...]
< HTTP/2 200 
< content-type: application/x-msdownload
< content-length: 577850088
```

This PR adds the "noredirect" URL parameter, which will allow all future Chocolatey packages to install the requested version of Screaming Frog, even if a newer version is already available.

I've also used this opportunity to update the information to the latest release of Screaming Frog.